### PR TITLE
Switch from QEMU emulation to Go Cross Compiling

### DIFF
--- a/.github/workflows/multi-platform-docker-publish.yml
+++ b/.github/workflows/multi-platform-docker-publish.yml
@@ -123,14 +123,13 @@ jobs:
 
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests
-        env:
-          DRYRUN: ${{ github.event_name != 'pull_request' }}
+        if: github.event_name != 'pull_request'
         run: |
           echo $DRYRUN
           echo ${DRYRUN:+--dry-run}
           echo ${{ github.event_name != 'pull_request' }}
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *) ${DRYRUN:+--dry-run}
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
 
       - name: Inspect image
         if: github.event_name != 'pull_request'

--- a/.github/workflows/multi-platform-docker-publish.yml
+++ b/.github/workflows/multi-platform-docker-publish.yml
@@ -55,7 +55,7 @@ jobs:
         uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
         with:
           platforms: ${{ matrix.platform }}
-          tags: ${{ env.IMAGE_NAME }}
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
 

--- a/.github/workflows/multi-platform-docker-publish.yml
+++ b/.github/workflows/multi-platform-docker-publish.yml
@@ -39,7 +39,7 @@ jobs:
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
       - name: Docker meta
         id: meta
-        uses: uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.IMAGE_NAME }}
       
@@ -112,7 +112,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |

--- a/.github/workflows/multi-platform-docker-publish.yml
+++ b/.github/workflows/multi-platform-docker-publish.yml
@@ -39,7 +39,7 @@ jobs:
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804
+        uses: uses: docker/metadata-action@v5
         with:
           images: ${{ env.IMAGE_NAME }}
       
@@ -54,7 +54,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
+        uses: docker/setup-buildx-action@v3
 
       - name: Build and push
         id: build
@@ -72,7 +72,7 @@ jobs:
           touch "${{ runner.temp }}/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@v4
         with:
           name: digests-${{ env.PLATFORM_PAIR }}
           path: ${{ runner.temp }}/digests/*
@@ -91,7 +91,7 @@ jobs:
       - build
     steps:
       - name: Download digests
-        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e
+        uses: actions/download-artifact@v4
         with:
           path: ${{ runner.temp }}/digests
           pattern: digests-*
@@ -108,11 +108,11 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
+        uses: docker/setup-buildx-action@v3
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804
+        uses: uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |

--- a/.github/workflows/multi-platform-docker-publish.yml
+++ b/.github/workflows/multi-platform-docker-publish.yml
@@ -131,4 +131,4 @@ jobs:
 
       - name: Inspect image
         run: |
-          docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/multi-platform-docker-publish.yml
+++ b/.github/workflows/multi-platform-docker-publish.yml
@@ -1,4 +1,4 @@
-name: Docker
+name: cross-compile build
 # from GitHub's suggusted Publish Docker Container and https://docs.docker.com/build/ci/github-actions/multi-platform/#build-and-load-multi-platform-images
 on:
   push:
@@ -20,24 +20,22 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-      # This is used to complete the identity challenge
-      # with sigstore/fulcio when running outside of PRs.
-      id-token: write
-
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
     steps:
-      - name: Set up Docker
-        uses: docker/setup-docker-action@b60f85385d03ac8acfca6d9996982511d8620a19 # v4.3.0
+      - name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
         with:
-          daemon-config: |
-            {
-              "debug": true,
-              "features": {
-                "containerd-snapshotter": true
-              }
-            }
+          images: ${{ env.IMAGE_NAME }}
       
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
@@ -49,33 +47,74 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-
-      # Extract metadata (tags, labels) for Docker
-      # https://github.com/docker/metadata-action
-      - name: Extract Docker metadata
-        id: meta
-        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=schedule
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=ref,event=branch
-            type=ref,event=pr
-            type=sha
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Build and push
+        id: build
         uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
         with:
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
+          platforms: ${{ matrix.platform }}
+          tags: ${{ env.IMAGE_NAME }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
-          load: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/multi-platform-docker-publish.yml
+++ b/.github/workflows/multi-platform-docker-publish.yml
@@ -61,7 +61,7 @@ jobs:
         uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
         with:
           platforms: ${{ matrix.platform }}
-          tags: ghcr.io/danielwelliott/caddy-porkbun
+          tags: ${{ env.IMAGE_NAME }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
 
@@ -118,6 +118,8 @@ jobs:
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests
         run: |
+          echo docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.IMAGE_NAME }}@sha256:%s ' *)
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.IMAGE_NAME }}@sha256:%s ' *)
 

--- a/.github/workflows/multi-platform-docker-publish.yml
+++ b/.github/workflows/multi-platform-docker-publish.yml
@@ -81,6 +81,12 @@ jobs:
 
   merge:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
     needs:
       - build
     steps:

--- a/.github/workflows/multi-platform-docker-publish.yml
+++ b/.github/workflows/multi-platform-docker-publish.yml
@@ -14,7 +14,7 @@ env:
   # Use docker.io for Docker Hub if empty
   REGISTRY: ghcr.io
   # github.repository as <account>/<repo>
-  IMAGE_NAME: ${{ env.REGISTRY }}/${{ github.repository }}
+  IMAGE_NAME: ${{ github.repository }}
 
 
 jobs:
@@ -35,7 +35,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action

--- a/.github/workflows/multi-platform-docker-publish.yml
+++ b/.github/workflows/multi-platform-docker-publish.yml
@@ -1,5 +1,5 @@
 name: cross-compile build
-# from GitHub's suggusted Publish Docker Container and https://docs.docker.com/build/ci/github-actions/multi-platform/#build-and-load-multi-platform-images
+# Tweaked from https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners to work with ghcr.io
 on:
   push:
     branches: [ "main" ]
@@ -124,8 +124,6 @@ jobs:
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests
         run: |
-          echo docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.IMAGE_NAME }}@sha256:%s ' *)
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
 

--- a/.github/workflows/multi-platform-docker-publish.yml
+++ b/.github/workflows/multi-platform-docker-publish.yml
@@ -108,7 +108,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=ref,event=branch
             type=ref,event=pr

--- a/.github/workflows/multi-platform-docker-publish.yml
+++ b/.github/workflows/multi-platform-docker-publish.yml
@@ -63,7 +63,7 @@ jobs:
           platforms: ${{ matrix.platform }}
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,push-by-digest=true,name-canonical=true,push=${{github.event_name != 'pull_request'}}
 
       - name: Export digest
         run: |
@@ -123,10 +123,16 @@ jobs:
 
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests
+        env:
+          DRYRUN: ${{ github.event_name != 'pull_request' }}
         run: |
+          echo $DRYRUN
+          echo ${DRYRUN:+--dry-run}
+          echo ${{ github.event_name != 'pull_request' }}
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *) ${DRYRUN:+--dry-run}
 
       - name: Inspect image
+        if: github.event_name != 'pull_request'
         run: |
           docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/multi-platform-docker-publish.yml
+++ b/.github/workflows/multi-platform-docker-publish.yml
@@ -41,7 +41,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.IMAGE_NAME }}
       
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
@@ -61,7 +61,7 @@ jobs:
         uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
         with:
           platforms: ${{ matrix.platform }}
-          tags: usertest/reponame
+          tags: ghcr.io/danielwelliott/caddy-porkbun:cross-compile
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
 

--- a/.github/workflows/multi-platform-docker-publish.yml
+++ b/.github/workflows/multi-platform-docker-publish.yml
@@ -2,7 +2,7 @@ name: cross-compile build
 # from GitHub's suggusted Publish Docker Container and https://docs.docker.com/build/ci/github-actions/multi-platform/#build-and-load-multi-platform-images
 on:
   push:
-    branches: [ "main", "cross-compile" ]
+    branches: [ "main" ]
     # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
   pull_request:
@@ -39,9 +39,9 @@ jobs:
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804
         with:
-          images: ${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
@@ -54,7 +54,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
 
       - name: Build and push
         id: build
@@ -72,7 +72,7 @@ jobs:
           touch "${{ runner.temp }}/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: digests-${{ env.PLATFORM_PAIR }}
           path: ${{ runner.temp }}/digests/*
@@ -91,7 +91,7 @@ jobs:
       - build
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e
         with:
           path: ${{ runner.temp }}/digests
           pattern: digests-*
@@ -108,11 +108,11 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |

--- a/.github/workflows/multi-platform-docker-publish.yml
+++ b/.github/workflows/multi-platform-docker-publish.yml
@@ -127,7 +127,7 @@ jobs:
           echo docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.IMAGE_NAME }}@sha256:%s ' *)
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.IMAGE_NAME }}@sha256:%s ' *)
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
 
       - name: Inspect image
         run: |

--- a/.github/workflows/multi-platform-docker-publish.yml
+++ b/.github/workflows/multi-platform-docker-publish.yml
@@ -61,7 +61,7 @@ jobs:
         uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
         with:
           platforms: ${{ matrix.platform }}
-          tags: ${{ env.IMAGE_NAME }}
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
 

--- a/.github/workflows/multi-platform-docker-publish.yml
+++ b/.github/workflows/multi-platform-docker-publish.yml
@@ -14,7 +14,7 @@ env:
   # Use docker.io for Docker Hub if empty
   REGISTRY: ghcr.io
   # github.repository as <account>/<repo>
-  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME: ${{ env.REGISTRY }}/${{ github.repository }}
 
 
 jobs:

--- a/.github/workflows/multi-platform-docker-publish.yml
+++ b/.github/workflows/multi-platform-docker-publish.yml
@@ -61,7 +61,7 @@ jobs:
         uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
         with:
           platforms: ${{ matrix.platform }}
-          tags: ghcr.io/${{ github.repository }}
+          tags: ghcr.io/danielwelliott/caddy-porkbun
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
 

--- a/.github/workflows/multi-platform-docker-publish.yml
+++ b/.github/workflows/multi-platform-docker-publish.yml
@@ -41,7 +41,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.IMAGE_NAME }}
       
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action

--- a/.github/workflows/multi-platform-docker-publish.yml
+++ b/.github/workflows/multi-platform-docker-publish.yml
@@ -61,7 +61,7 @@ jobs:
         uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
         with:
           platforms: ${{ matrix.platform }}
-          tags: ${{ env.IMAGE_NAME }}
+          tags: usertest/reponame
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
 

--- a/.github/workflows/multi-platform-docker-publish.yml
+++ b/.github/workflows/multi-platform-docker-publish.yml
@@ -20,6 +20,12 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -55,7 +61,7 @@ jobs:
         uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
         with:
           platforms: ${{ matrix.platform }}
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ env.IMAGE_NAME }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
 

--- a/.github/workflows/multi-platform-docker-publish.yml
+++ b/.github/workflows/multi-platform-docker-publish.yml
@@ -61,7 +61,7 @@ jobs:
         uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
         with:
           platforms: ${{ matrix.platform }}
-          tags: ghcr.io/danielwelliott/caddy-porkbun:cross-compile
+          tags: ghcr.io/${{ github.repository }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
 

--- a/.github/workflows/multi-platform-docker-publish.yml
+++ b/.github/workflows/multi-platform-docker-publish.yml
@@ -2,7 +2,7 @@ name: cross-compile build
 # from GitHub's suggusted Publish Docker Container and https://docs.docker.com/build/ci/github-actions/multi-platform/#build-and-load-multi-platform-images
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "cross-compile" ]
     # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
   pull_request:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM --platform=$BUILDPLATFORM docker.io/library/caddy:2.9.1-builder AS builder
 
+ARG TARGETOS TARGETARCH
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} xcaddy build \
     --with github.com/caddy-dns/porkbun
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM docker.io/library/caddy:2.9.1-builder AS builder
+FROM --platform=$BUILDPLATFORM docker.io/library/caddy:2.9.1-builder AS builder
 
-RUN xcaddy build \
+RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} xcaddy build \
     --with github.com/caddy-dns/porkbun
 
 FROM docker.io/library/caddy:2.9.1


### PR DESCRIPTION
Followed [This docker guide](https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners) for multi-platform images, adding the registry name to the namespace and repo almost everywhere. (Also change my GitHub username to all lowercase to make things easier.)

The ARM64 caddy image is now cross compiled from an AMD64 builder instead of compiled in an emulated ARM64 builder, and the two builds are also concurrent to save a minute or two (not that it's much compared to the thirteen minutes the emulation -> cross compiling shaved off).